### PR TITLE
Configuration to work on even days

### DIFF
--- a/birthday-bot/lambdas/slackPost.js
+++ b/birthday-bot/lambdas/slackPost.js
@@ -9,37 +9,46 @@ const authToken = process.env.slackAuthToken;
 function postToSlack(channel, callback) {
   let url = "https://slack.com/api/chat.postMessage";
   let message = birthdays.getBirthdaysMessage();
+  let response;
 
-  fetch(url, {
-    method: "post",
-    body: JSON.stringify({
-        text: message,
-        channel: channel
-    }),
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${authToken}`
-    }
-  })
-  .then(res => res.json())
-  .then(json => {
-    console.log(json);
-
-    let response;
-    if (json.ok) {
-      response = {
-        statusCode: 200,
-        body: 'Message sent!'
+  if (message) {
+    fetch(url, {
+      method: "post",
+      body: JSON.stringify({
+          text: message,
+          channel: channel
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${authToken}`
       }
-    } else {
-      response = {
-        statusCode: 501,
-        body: JSON.stringify(json)
+    })
+    .then(res => res.json())
+    .then(json => {
+      console.log(json);
+  
+      if (json.ok) {
+        response = {
+          statusCode: 200,
+          body: 'Message sent!'
+        }
+      } else {
+        response = {
+          statusCode: 501,
+          body: JSON.stringify(json)
+        }
       }
+  
+      callback(response)
+    });
+  } else {
+    response = {
+      statusCode: 200,
+      body: `There aren't any birthday today.`
     }
-
     callback(response)
-  });
+  }
+  
 }
 
 exports.proactive = (event, context, callback) => {

--- a/birthday-bot/mock/bambooUsers.json
+++ b/birthday-bot/mock/bambooUsers.json
@@ -1,50 +1,10 @@
 [
-    {
-        "birthday": "07/08",
-        "mail": "lazaro.ansaldi@southworks.com"
-    },
-    {
-        "birthday": "12/08",
-        "mail": "joaquin.fiora@southworks.com"
-    },
-    {
-        "birthday": "14/08",
-        "mail": "mirco.fiocchi@southworks.com"
-    },
-    {
-        "birthday": "15/08",
-        "mail": "eloy.vega@southworks.com"
-    },
-    {
-        "birthday": "15/08",
-        "mail": "christian.gelman@southworks.com"
-    },
-    {
-        "birthday": "16/08",
-        "mail": "alejo.pereyra@southworks.com"
-    },
-    {
-        "birthday": "17/08",
-        "mail": "i-nmachulsky@southworks.com"
-    },
-    {
-        "birthday": "18/08",
-        "mail": "damian.steimberg@southworks.com"
-    },
-    {
-        "birthday": "19/08",
-        "mail": "nadia.chiappero@southworks.com"
-    },
-    {
-        "birthday": "20/08",
-        "mail": "santiago.gomez@southworks.com"
-    },
-    {
-        "birthday": "20/08",
-        "mail": "franco.zuccarelli@southworks.com"
-    },
-    {
-        "birthday": "20/08",
-        "mail": "hector.mazzucotelli@southworks.com"
-    }
+  {
+    "birthday": "DD/MM",
+    "mail": "john.doe@mail.com"
+  },
+  {
+    "birthday": "DD/MM",
+    "mail": "jane.doe@mail.com"
+  }
 ]

--- a/birthday-bot/mock/bambooUsers.json
+++ b/birthday-bot/mock/bambooUsers.json
@@ -1,26 +1,50 @@
 [
     {
-        "mail": "facundo.martin@southworks.com",
-        "birthday": "05/08"
+        "birthday": "07/08",
+        "mail": "lazaro.ansaldi@southworks.com"
     },
     {
-        "mail": "billy.delgado@southworks.com",
-        "birthday": "05/08"
+        "birthday": "12/08",
+        "mail": "joaquin.fiora@southworks.com"
     },
     {
-        "mail": "angel.szymczak@southworks.com",
-        "birthday": "05/08"
+        "birthday": "14/08",
+        "mail": "mirco.fiocchi@southworks.com"
     },
     {
-        "mail": "nahuel.schlegel@southworks.com",
-        "birthday": "05/08"
+        "birthday": "15/08",
+        "mail": "eloy.vega@southworks.com"
     },
     {
-        "mail": "gonzalo.munoz@southworks.com",
-        "birthday": "02/08"
+        "birthday": "15/08",
+        "mail": "christian.gelman@southworks.com"
     },
     {
-        "mail": "lazaro.ansaldi@southworks.com",
-        "birthday": "07/08"
+        "birthday": "16/08",
+        "mail": "alejo.pereyra@southworks.com"
+    },
+    {
+        "birthday": "17/08",
+        "mail": "i-nmachulsky@southworks.com"
+    },
+    {
+        "birthday": "18/08",
+        "mail": "damian.steimberg@southworks.com"
+    },
+    {
+        "birthday": "19/08",
+        "mail": "nadia.chiappero@southworks.com"
+    },
+    {
+        "birthday": "20/08",
+        "mail": "santiago.gomez@southworks.com"
+    },
+    {
+        "birthday": "20/08",
+        "mail": "franco.zuccarelli@southworks.com"
+    },
+    {
+        "birthday": "20/08",
+        "mail": "hector.mazzucotelli@southworks.com"
     }
 ]

--- a/birthday-bot/mock/slackUsers.json
+++ b/birthday-bot/mock/slackUsers.json
@@ -1,26 +1,50 @@
 [
   {
-    "id": "U013DCJKNHX",
-    "mail": "facundo.martin@southworks.com"
-  },
-  {
-    "id": "UC52ERRLN",
-    "mail": "billy.delgado@southworks.com"
-  },
-  {
-    "id": "U013TPTSYFP",
-    "mail": "angel.szymczak@southworks.com"
-  },
-  {
-    "id": "U013V63UCQ3",
-    "mail": "nahuel.schlegel@southworks.com"
-  },
-  {
-    "id": "U012KNDEKJT",
-    "mail": "gonzalo.munoz@southworks.com"
-  },
-  {
     "id": "U012C71MHE0",
     "mail": "lazaro.ansaldi@southworks.com"
+  },
+  {
+    "id": "UL8NHUS8Z",
+    "mail": "joaquin.fiora@southworks.com"
+  },
+  {
+    "id": "U0103909GC8",
+    "mail": "mirco.fiocchi@southworks.com"
+  },
+  {
+    "id": "UEJ1TE6HJ",
+    "mail": "eloy.vega@southworks.com"
+  },
+  {
+    "id": "U8TQW1DPG",
+    "mail": "christian.gelman@southworks.com"
+  },
+  {
+    "id": "U014T5HCN3E",
+    "mail": "alejo.pereyra@southworks.com"
+  },
+  {
+    "id": "U015MN7QZV4",
+    "mail": "i-nmachulsky@southworks.com"
+  },
+  {
+    "id": "UMLP2663D",
+    "mail": "damian.steimberg@southworks.com"
+  },
+  {
+    "id": "U013TKBHSKX",
+    "mail": "nadia.chiappero@southworks.com"
+  },
+  {
+    "id": "UE1KF7C1H",
+    "mail": "santiago.gomez@southworks.com"
+  },
+  {
+    "id": "U014M6Z5WM9",
+    "mail": "franco.zuccarelli@southworks.com"
+  },
+  {
+    "id": "U014JS2NVNC",
+    "mail": "hector.mazzucotelli@southworks.com"
   }
 ]

--- a/birthday-bot/mock/slackUsers.json
+++ b/birthday-bot/mock/slackUsers.json
@@ -1,50 +1,10 @@
 [
   {
-    "id": "U012C71MHE0",
-    "mail": "lazaro.ansaldi@southworks.com"
+    "id": "XXXXXXXXXXX",
+    "mail": "john.doe@mail.com"
   },
   {
-    "id": "UL8NHUS8Z",
-    "mail": "joaquin.fiora@southworks.com"
-  },
-  {
-    "id": "U0103909GC8",
-    "mail": "mirco.fiocchi@southworks.com"
-  },
-  {
-    "id": "UEJ1TE6HJ",
-    "mail": "eloy.vega@southworks.com"
-  },
-  {
-    "id": "U8TQW1DPG",
-    "mail": "christian.gelman@southworks.com"
-  },
-  {
-    "id": "U014T5HCN3E",
-    "mail": "alejo.pereyra@southworks.com"
-  },
-  {
-    "id": "U015MN7QZV4",
-    "mail": "i-nmachulsky@southworks.com"
-  },
-  {
-    "id": "UMLP2663D",
-    "mail": "damian.steimberg@southworks.com"
-  },
-  {
-    "id": "U013TKBHSKX",
-    "mail": "nadia.chiappero@southworks.com"
-  },
-  {
-    "id": "UE1KF7C1H",
-    "mail": "santiago.gomez@southworks.com"
-  },
-  {
-    "id": "U014M6Z5WM9",
-    "mail": "franco.zuccarelli@southworks.com"
-  },
-  {
-    "id": "U014JS2NVNC",
-    "mail": "hector.mazzucotelli@southworks.com"
+    "id": "XXXXXXXXXXX",
+    "mail": "jane.doe@mail.com"
   }
 ]

--- a/birthday-bot/packages/slack.js
+++ b/birthday-bot/packages/slack.js
@@ -13,7 +13,7 @@ const getBirthdayGreeting = (emails) => {
     return `${icon1} ${icon2} Happy birthday ${users}! ${icon2} ${icon1}`;
   }
 
-  return `We don't have any birthday today ${icon3} ${icon4}`
+  return false;
 }
 
 /* Returns an Array with Slack users IDs by email */

--- a/birthday-bot/serverless.yml
+++ b/birthday-bot/serverless.yml
@@ -23,7 +23,7 @@ functions:
   proactiveBirthdayMessage:
     handler: lambdas/slackPost.proactive
     events:
-      - schedule: cron(50 11 * * ? *)
+      - schedule: cron(50 11 2-30/2 * ? *)
     environment:
       slackAuthToken: ${ssm:/birthday-bot/dev/authToken~true}
 


### PR DESCRIPTION
### Description
This pull request updates the configuration to work just on even days. Also removes the non-birthdays message and clean data from JSON files and adds examples to show the desirable JSONs structure.

### Changes made

- Updates the cron expression on the serverless.yml file for the proactiveBirthdayMessage function.
- Modification on the Slack package to return false when there are no birthdays
- The Bamboo and Slack JSONs with the birthdays were cleaned and some example data was added to it.