### PR TITLE
Add permissions to execute getParameter of SSM

### DIFF
--- a/birthday-bot/serverless.yml
+++ b/birthday-bot/serverless.yml
@@ -14,7 +14,13 @@ provider:
     - Effect: Allow
       Action:
         - ssm:GetParameter
-      Resource: 'arn:aws:ssm:us-east-1:839649480346:parameter${self:provider.environment.AUTH_TOKEN_SSM}'
+      Resource:
+        - 'Fn::Join':
+            - ':'
+            - - 'arn:aws:ssm'
+              - Ref: 'AWS::Region'
+              - Ref: 'AWS::AccountId'
+              - 'parameter${self:provider.environment.AUTH_TOKEN_SSM}'
 
 functions:
   configChannel:


### PR DESCRIPTION
It resolves another bug inserted by the [PR#21](https://github.com/southworks/amazon-lex-happybirthday-bamboohr-slack-bot/pull/21)

## Description
When you deploy the Lambdas and you want to run it in the cloud it through an Exception like this:
> "AccessDeniedException: User: .../birthday-bot-dev-configChannel is not authorized to perform: ssm:GetParameter on resource: arn:aws:ssm:us-east-1:839649480346:parameter/birthday-bot/dev/authToken"

## Specific Changes
This adds the permission needed to the serverless.yml file.